### PR TITLE
Adding an option to delete journal-messages

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -40,6 +40,12 @@ couchbase-journal {
 
   # Max batch size for messages
   max-message-batch-size = 200
+
+  # Wheather to add tombstones documents to the bucket or to acctually remove the documents
+  #
+  #   "true" - means a deletion marker documented will be added to the bucket, marking other journal messages as removed
+  #   "false" - means that journal messages will be actually removed from the bucket
+  tombstone = "true"
 }
 
 couchbase-snapshot-store {

--- a/src/main/scala/akka/persistence/couchbase/CouchbasePluginConfig.scala
+++ b/src/main/scala/akka/persistence/couchbase/CouchbasePluginConfig.scala
@@ -60,6 +60,8 @@ trait CouchbaseJournalConfig extends CouchbasePluginConfig {
 
   def maxMessageBatchSize: Int
 
+  def tombstone: Boolean
+
 }
 
 class DefaultCouchbaseJournalConfig(config: Config)
@@ -69,6 +71,8 @@ class DefaultCouchbaseJournalConfig(config: Config)
   override val replayDispatcherId = config.getString("replay-dispatcher")
 
   override val maxMessageBatchSize = config.getInt("max-message-batch-size")
+
+  override val tombstone = config.getBoolean("tombstone")
 }
 
 object CouchbaseJournalConfig {

--- a/src/main/scala/akka/persistence/couchbase/journal/CouchbaseJournal.scala
+++ b/src/main/scala/akka/persistence/couchbase/journal/CouchbaseJournal.scala
@@ -75,8 +75,7 @@ class CouchbaseJournal extends AsyncWriteJournal with CouchbaseRecovery with Cou
 
       CouchbaseRecovery.replayMessages(persistenceId, 0L, toSequenceNr, Long.MaxValue) { persistent =>
         if (!toDelete.headOption.contains(persistent.sequenceNr)) {
-//          -1 because it should take into account journal message sequence number 0
-          toDelete = (persistent.sequenceNr-1) :: toDelete
+          toDelete = persistent.sequenceNr :: toDelete
         }
       }.flatMap { _ =>
         val groups = toDelete.reverse.grouped(config.maxMessageBatchSize)


### PR DESCRIPTION
I know that the journal plugin at the moment is implemented so that it uses Couchbase in a pure log-oriented way, which is ok if the system is designed this way, but it is always nice to have some more flexibility and options while using the plugin. 

In this PR I try to add an option to physical remove journal-messages from couchbase.

`Why this change?`

We encountered some issues related to couchbase bucket documents number continuously increasing, and having a separate service to remove the documents marked as deleted is not the best option. According to akka specification after a snapshot is created we do not have to keep persisted journal-messages anymore and it is totally fine to remove those messages as all the information required is included in the snapshot and those messages does not have to be replayed.

I think more people who uses this plugin will find the option helpful.

`How is it implemented?`

Based on the facts mentioned above, I changed the plugin to have an actual delete action when required, by adding a `tombstone` flag in the `couchbase-journal` configuration.
This flag is set by default to `true`, so it will be backward compatible with previous version of the plugin, so when it is set to `true` - a deletion marker document will
be added when `asyncDeleteMessagesTo` is called (this is current functionality), but when it is set to `false` it will actually send a request to remove the document from the bucket.
The deletion is done using batching mutation technique.

All the changes done:

 - adding `tombstone` parameter in the config file for couchbase-journal section, this parameter can be `true` - when you want to add deletion markers of removed documents, and `false` - when you actually want the journals to be removed from the bucket
 - `akka.persistence.couchbase.journal.CouchbaseStatements` - adding another method that will handle deletion requests to couchbase
 - `akka.persistence.couchbase.journal.CouchbaseJournal` - modified `asyncDeleteMessagesTo` to call deletion handler when `tombstone` = `false`
 - `akka.persistence.couchbase.CouchbaseJournalConfig` - modified to read the new `tombstone` parameter from the configuration

