### PR TITLE
Fix observable merge operation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   # Wait until started
   - while ! echo exit | nc localhost 8091; do sleep 10; done
   # Setup Bucket for test
-  - /opt/couchbase/bin/couchbase-cli bucket-create -c 127.0.0.1:8091 --bucket=akka --bucket-password= --bucket-type=couchbase --bucket-port=11211 --bucket-ramsize=100 --bucket-replica=0 -u Administrator -p password
+  - /opt/couchbase/bin/couchbase-cli bucket-create -c 127.0.0.1:8091 --bucket=akka --bucket-password= --bucket-type=couchbase --bucket-port=11211 --bucket-ramsize=100 --bucket-replica=0 --enable-flush=1 -u Administrator -p password
 
 notifications:
   email:

--- a/build.sbt
+++ b/build.sbt
@@ -34,11 +34,12 @@ licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html
 
 bintrayOrganization := Some("productfoundry")
 
-val akkaVer = "2.4.6"
+val akkaVer = "2.5.3"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-persistence" % akkaVer,
-  "com.couchbase.client" % "java-client" % "2.2.7",
+  "com.couchbase.client" % "java-client" % "2.4.7",
+  "com.couchbase.client" % "core-io" % "1.4.7",
   "commons-codec" % "commons-codec" % "1.10",
   "com.typesafe.akka" %% "akka-persistence-tck" % akkaVer % "test",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,6 @@ val akkaVer = "2.5.3"
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-persistence" % akkaVer,
   "com.couchbase.client" % "java-client" % "2.4.7",
-  "com.couchbase.client" % "core-io" % "1.4.7",
   "commons-codec" % "commons-codec" % "1.10",
   "com.typesafe.akka" %% "akka-persistence-tck" % akkaVer % "test",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",

--- a/src/main/scala/akka/persistence/couchbase/journal/JournalMessage.scala
+++ b/src/main/scala/akka/persistence/couchbase/journal/JournalMessage.scala
@@ -20,7 +20,8 @@ case class JournalMessage(persistenceId: String,
                           marker: Marker.Marker,
                           manifest: Option[String] = None,
                           message: Option[Message] = None,
-                          tags: Set[String] = Set.empty)
+                          tags: Set[String] = Set.empty,
+                          journalId: Option[String] = None)
 
 object JournalMessage {
 
@@ -46,7 +47,7 @@ object JournalMessage {
     jsonObject
   }
 
-  def deserialize(jsonObject: JsonObject): JournalMessage = {
+  def deserialize(jsonObject: JsonObject, documentId: String): JournalMessage = {
     JournalMessage(
       jsonObject.getString("persistenceId"),
       jsonObject.getLong("sequenceNr"),
@@ -55,7 +56,8 @@ object JournalMessage {
       Option(jsonObject.getString("message")).map(Message.deserialize),
       Option(jsonObject.getArray("tags")).map { tagArray =>
         tagArray.iterator().asScala.map(_.asInstanceOf[String]).toSet
-      }.getOrElse(Set.empty)
+      }.getOrElse(Set.empty),
+      Option(documentId)
     )
   }
 }

--- a/src/main/scala/akka/persistence/couchbase/journal/JournalMessageBatch.scala
+++ b/src/main/scala/akka/persistence/couchbase/journal/JournalMessageBatch.scala
@@ -26,12 +26,12 @@ object JournalMessageBatch {
       .put("messages", journalMessageBatch.messages.map(JournalMessage.serialize).foldLeft(JsonArray.create())(_ add _))
   }
 
-  def deserialize(jsonObject: JsonObject): JournalMessageBatch = {
+  def deserialize(jsonObject: JsonObject, documentId: String): JournalMessageBatch = {
 
     JournalMessageBatch(
       jsonObject.getString("dataType"),
       jsonObject.getArray("messages").iterator().asScala.map {
-        message => JournalMessage.deserialize(message.asInstanceOf[JsonObject])
+        message => JournalMessage.deserialize(message.asInstanceOf[JsonObject], documentId)
       }.toSeq
     )
   }


### PR DESCRIPTION
The PR that was merged before for physical remove of the entries from the bucket works fine until it hits a spike of actions, so it looks to be failing to operate when there is a load of actions, this change is intended to fix this issue and increase the performance of the plugin under load.

`Why this change?`
1. There is an issue with `Observable.merge(...)` operation under load, it becomes too zealous of JVM resources and fails with a nasty stack trace, so I fixed it by rewriting that part of the code with a more appropriate one and tested under load this time, it performed as expected, the change is also written in a batching mutation approach.

2. Looks like I was using the internal sequence id in order to build the document key for the document that needs to be removed, it was a wrong approach as the sequence number is not equal to document sequence, so rewritten that part too to pass the correct document key to be removed, verified this under some load tests with Akka 2.5.3, the entries number in the bucket are kept according to the configuration, all the unnecessary entries are removed.

3. Updated `Akka` to 2.5.3 and `couchbase java-client` to 2.4.7 in order to have a better compatibility and performance with couchbase 4.6+