### PR TITLE
add couchbase authentication - added username

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -29,6 +29,7 @@ couchbase-journal {
   bucket {
     nodes = ["couchbase://localhost:8091"]
     bucket = "akka"
+    username = ""
     password = ""
   }
 
@@ -79,6 +80,7 @@ couchbase-snapshot-store {
   bucket {
     nodes = ["couchbase://localhost:8091"]
     bucket = "akka"
+    username = ""
     password = ""
   }
 
@@ -114,6 +116,7 @@ couchbase-replay {
   bucket {
     nodes = ["couchbase://localhost:8091"]
     bucket = "akka"
+    username = ""
     password = ""
   }
 


### PR DESCRIPTION
Hi, your library is awesome... just what I needed.  Couchbase has added: 

> For versions of Couchbase Server 5.0 and beyond, Role-Based Access Control (RBAC) is applied to all cluster-resources. Under RBAC, bucket-passwords are no longer used: instead, a username and user-password must be specified.
https://developer.couchbase.com/documentation/server/current/sdk/java/sdk-authentication-overview.html

So I am working on a fork with this feature added, I'm still testing it, but wanted to get your early feedback on this change / pull request.

Thanks!!